### PR TITLE
Replace SBAPCR person with SBAPCREmail plain text

### DIFF
--- a/src/api/DomainObjects.ts
+++ b/src/api/DomainObjects.ts
@@ -146,7 +146,7 @@ export interface IProcess {
   Modified: DateTime;
   CurrentStage: Stages;
   CurrentAssignee: IPerson;
-  SBAPCR?: IPerson;
+  SBAPCREmail?: string;
   CurrentStageStartDate: DateTime;
   OL: string;
   "odata.etag": string;

--- a/src/api/PCREmailsApi.ts
+++ b/src/api/PCREmailsApi.ts
@@ -1,0 +1,18 @@
+export const checkSBAPCRValid = (pcrEmail: string | undefined) => {
+  if (pcrEmail === undefined || pcrEmail === "") {
+    return "You must provide an Email for SBA PCR if sending to that stage";
+  } else if (
+    // Check that the value matches email address format, and ends in .gov or .mil
+    // Based on https://www.oreilly.com/library/view/regular-expressions-cookbook/9781449327453/ch04s01.html
+    !/^[\w!#$%&'*+/=?`{|}~^-]+(?:\.[\w!#$%&'*+/=?`{|}~^-]+)*@(?:[A-Z0-9-]+\.)+(gov|mil)$/i.test(
+      pcrEmail
+    )
+    //!/^\w+([.-]?\w+)*@\w+([.-]?\w+)*((\.gov)|(\.mil))$/.test(
+    //  pcrEmail.toLowerCase()
+    //)
+  ) {
+    return "SBA PCR Emai address is not a valid .gov or .mil address";
+  } else {
+    return undefined;
+  }
+};

--- a/src/api/ProcessesApi.ts
+++ b/src/api/ProcessesApi.ts
@@ -157,9 +157,7 @@ export default class ProcessesApi implements IProcessesApi {
           "CurrentAssignee/Id",
           "CurrentAssignee/Title",
           "CurrentAssignee/EMail",
-          "SBAPCR/Id",
-          "SBAPCR/Title",
-          "SBAPCR/EMail",
+          "SBAPCREmail",
           "CurrentStageStartDate",
           "IsDeleted",
           "OL"
@@ -168,8 +166,7 @@ export default class ProcessesApi implements IProcessesApi {
           "Buyer",
           "ContractingOfficer",
           "SmallBusinessProfessional",
-          "CurrentAssignee",
-          "SBAPCR"
+          "CurrentAssignee"
         )
         .get();
       return process && !process.IsDeleted
@@ -218,9 +215,7 @@ export default class ProcessesApi implements IProcessesApi {
           "CurrentAssignee/Id",
           "CurrentAssignee/Title",
           "CurrentAssignee/EMail",
-          "SBAPCR/Id",
-          "SBAPCR/Title",
-          "SBAPCR/EMail",
+          "SBAPCREmail",
           "CurrentStageStartDate",
           "OL"
         )
@@ -228,8 +223,7 @@ export default class ProcessesApi implements IProcessesApi {
           "Buyer",
           "ContractingOfficer",
           "SmallBusinessProfessional",
-          "CurrentAssignee",
-          "SBAPCR"
+          "CurrentAssignee"
         );
       let queryString = "ContentType ne 'Document' and IsDeleted ne 1";
       if (owner) {
@@ -450,7 +444,7 @@ interface ISubmitProcess {
   Modified?: string;
   CurrentStage: Stages;
   CurrentAssigneeId: number;
-  SBAPCRId?: number;
+  SBAPCREmail?: string;
   CurrentStageStartDate: string;
   IsDeleted?: boolean;
   OL: string;
@@ -481,7 +475,7 @@ interface SPProcess {
   Modified: string;
   CurrentStage: Stages;
   CurrentAssignee: IPerson;
-  SBAPCR?: IPerson;
+  SBAPCREmail?: string;
   CurrentStageStartDate: string;
   IsDeleted: boolean;
   OL?: string;
@@ -515,10 +509,7 @@ const spProcessToIProcess = (process: SPProcess): IProcess => {
     Modified: DateTime.fromISO(process.Modified),
     CurrentStage: process.CurrentStage,
     CurrentAssignee: new Person(process.CurrentAssignee),
-    SBAPCR:
-      process.SBAPCR && process.SBAPCR.EMail
-        ? new Person(process.SBAPCR)
-        : undefined,
+    SBAPCREmail: process.SBAPCREmail,
     CurrentStageStartDate: DateTime.fromISO(process.CurrentStageStartDate),
     OL: process.OL ?? "WPAFB",
     "odata.etag": process.__metadata.etag,
@@ -547,7 +538,7 @@ const processToSubmitProcess = (process: IProcess): ISubmitProcess => {
     MultipleAward: process.MultipleAward,
     CurrentStage: process.CurrentStage,
     CurrentAssigneeId: process.CurrentAssignee.Id,
-    SBAPCRId: process.SBAPCR ? process.SBAPCR.Id : undefined,
+    SBAPCREmail: process.SBAPCREmail,
     CurrentStageStartDate: process.CurrentStageStartDate.toISO(),
     IsDeleted: false,
     OL: process.OL ?? "WPAFB",

--- a/src/api/ProcessesApiDev.ts
+++ b/src/api/ProcessesApiDev.ts
@@ -74,11 +74,6 @@ export default class ProcessesApiDev implements IProcessesApi {
             Title: "Jeremy Clark",
             EMail: "me@example.com",
           }),
-          SBAPCR: new Person({
-            Id: 1,
-            Title: "Jeremy Clark",
-            EMail: "me@example.com",
-          }),
           CurrentStageStartDate: DateTime.local(),
           OL: "WPAFB",
           "odata.etag": "1",
@@ -113,11 +108,6 @@ export default class ProcessesApiDev implements IProcessesApi {
           Modified: DateTime.local(),
           CurrentStage: Stages.BUYER_REVIEW,
           CurrentAssignee: new Person({
-            Id: 2,
-            Title: "Robert Porterfield",
-            EMail: "rob@example.com",
-          }),
-          SBAPCR: new Person({
             Id: 2,
             Title: "Robert Porterfield",
             EMail: "rob@example.com",
@@ -162,11 +152,6 @@ export default class ProcessesApiDev implements IProcessesApi {
             Title: "Jeremy Clark",
             EMail: "me@example.com",
           }),
-          SBAPCR: new Person({
-            Id: 1,
-            Title: "Jeremy Clark",
-            EMail: "me@example.com",
-          }),
           CurrentStageStartDate: DateTime.local(),
           OL: "Tinker",
           "odata.etag": "1",
@@ -201,11 +186,6 @@ export default class ProcessesApiDev implements IProcessesApi {
           Modified: DateTime.local(),
           CurrentStage: Stages.BUYER_REVIEW,
           CurrentAssignee: new Person({
-            Id: 2,
-            Title: "Robert Porterfield",
-            EMail: "rob@example.com",
-          }),
-          SBAPCR: new Person({
             Id: 2,
             Title: "Robert Porterfield",
             EMail: "rob@example.com",

--- a/src/components/ProcessDetails/ProcessDetails.tsx
+++ b/src/components/ProcessDetails/ProcessDetails.tsx
@@ -83,7 +83,7 @@ export const ProcessDetails: FunctionComponent<IProcessDetailsProps> = (
           <strong>SBA PCR</strong>
         </Col>
         <Col md="7" sm="12" xs="12">
-          {props.process.SBAPCR?.Title}
+          {props.process.SBAPCREmail}
         </Col>
       </Row>
       <Row className="mb-2">


### PR DESCRIPTION
This is phase 1 of making the emails go out via PowerAutomate.  This is just turning a people person field into a free text field.  Created new field SBAPCREmail as a site column applying it to the Content Type SBAProcess.